### PR TITLE
More informative BaseObject.__repr__

### DIFF
--- a/FlowCytometryTools/core/bases.py
+++ b/FlowCytometryTools/core/bases.py
@@ -117,7 +117,8 @@ class BaseObject(object):
     Used for inheritance. 
     '''
 
-    def __repr__(self): return repr(self.ID)
+    def __repr__(self):
+        return '<{0} {1}>'.format(type(self).__name__, repr(self.ID))
 
     def save(self, path):
         """ Saves objec to a pickled file. """


### PR DESCRIPTION
I've noticed the default `__repr__` method for `FCMeasurement` just returns `repr(self.ID)` (inherited from BaseObject). This makes things slightly confusing if I'm working from the interpreter and type a variable in to remind myself what it is, as it looks like a string. Example:
```
In [1]: import FlowCytometryTools

In [2]: sample = FlowCytometryTools.FCMeasurement('my_sample', '/path/to/my_sample.fcs')

In [3]: sample
Out[3]: 'my_sample'
```
I believe it is typically preferred in python to have `eval(repr(my_obj)) == my_obj` when practical, but I'm not sure it is in this case. The other common pattern is to make it similar to the default for new-style classes, which is something like `'<mymodule.MyClass at 0x0000000>'`, with the address possibly replaced by something more informative. I thought something like the following would help:
```
In [6]: sample
Out[6]: <FCMeasurement 'my_sample'>
```
This style is consistent with existing conventions, makes the type of the object clear, and shows the ID which should uniquely identify the instance. I chose not to add the module because I thought `FlowCytometryTools.core.containers.FCMeasurement` was a bit too verbose. Making the change in `BaseObject` looks like it should work well in all derived classes which do not already override `__repr__`.