### PR TITLE
[core] Fix TypeError on FCMeasurement.subset() with Python 3.5

### DIFF
--- a/FlowCytometryTools/core/containers.py
+++ b/FlowCytometryTools/core/containers.py
@@ -331,7 +331,7 @@ class FCMeasurement(Measurement):
                     # EDGE CAES: Must return an empty sample
                     order = 'start'
                 if order == 'random':
-                    newdata = data.loc[sample(data.index, key)]  # Use loc not iloc here!!
+                    newdata = data.loc[sample(list(data.index), key)]  # Use loc not iloc here!!
                 elif order == 'start':
                     newdata = data.iloc[:key]
                 elif order == 'end':


### PR DESCRIPTION
Hi,

@elianeroosli found a bug when calling subset() with Python 3.5. She got the following exception:

```
Traceback (most recent call last):
  File "testcase.py", line 4, in <module>
    d.subsample(0.5)
  File "/home/dwatson/code/FlowCytometryTools/FlowCytometryTools/core/containers.py", line 334, in subsample
    newdata = data.loc[sample(data.index, key)]  # Use loc not iloc here!!
  File "/home/dwatson/code/FlowCytometryTools/env/lib/python3.5/random.py", line 311, in sample
    raise TypeError("Population must be a sequence or set.  For dicts, use list(d).")
TypeError: Population must be a sequence or set.  For dicts, use list(d).
```

My pull request fixes the bug, at least for python 3.5.

Minimum code to reproduce the error (run from the root directory of this repo):

```
import FlowCytometryTools as fct  

d = fct.FCMeasurement('test', 'FlowCytometryTools/tests/data/FlowCytometers/HTS_BD_LSR-II/HTS_BD_LSR_II_Mixed_Specimen_001_D6_D06.fcs')
d.subsample(0.5)
```

Cheers!
Douglas