### PR TITLE
Update docstring.py to use inspect.cleandoc inplace of dedent

### DIFF
--- a/FlowCytometryTools/core/docstring.py
+++ b/FlowCytometryTools/core/docstring.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import string
 
-from matplotlib.cbook import dedent
+from matplotlib import inspect
 
 
 class FormatDict(dict):
@@ -53,7 +53,7 @@ class DocReplacer(object):
         if func.__doc__:
             doc = func.__doc__
             if self.auto_dedent:
-                doc = dedent(doc)
+                doc = inspect.cleandoc(doc)
             func.__doc__ = self._format(doc)
         return func
 


### PR DESCRIPTION
This change is made to keep current with matplotlib library changes.  It is made in response to deprecation warning.