### PR TITLE
Remove use of "is" to compare with literals.

### DIFF
--- a/FlowCytometryTools/core/bases.py
+++ b/FlowCytometryTools/core/bases.py
@@ -582,9 +582,9 @@ class MeasurementCollection(collections.MutableMapping, BaseObject):
         func = lambda x: x.get_meta_fields(fields)
         meta_d = self.apply(func, ids=ids, applyto='measurement',
                             noneval=noneval, output_format='dict')
-        if output_format is 'dict':
+        if output_format == 'dict':
             return meta_d
-        elif output_format is 'DataFrame':
+        elif output_format == 'DataFrame':
             from pandas import DataFrame as DF
             meta_df = DF(meta_d, index=fields)
             return meta_df
@@ -1001,11 +1001,11 @@ class OrderedCollection(MeasurementCollection):
 
         # Note: result should be of type dict or collection for the code
         # below to work
-        if output_format is 'dict':
+        if output_format == 'dict':
             return result
-        elif output_format is 'DataFrame':
+        elif output_format == 'DataFrame':
             return self._dict2DF(result, noneval, dropna)
-        elif output_format is 'collection':
+        elif output_format == 'collection':
             return result
         else:
             msg = ("output_format must be either 'dict' or 'DataFrame'. " +

--- a/FlowCytometryTools/core/graph.py
+++ b/FlowCytometryTools/core/graph.py
@@ -540,10 +540,10 @@ def plot_heat_map(z, include_values=False,
     # to the annotation.
     auto_col_name, auto_col_labels, auto_row_name, auto_row_labels = extract_annotation(z)
 
-    if xtick_labels is 'auto': xtick_labels = auto_col_labels
-    if ytick_labels is 'auto': ytick_labels = auto_row_labels
-    if xlabel is 'auto': xlabel = auto_col_name
-    if ylabel is 'auto': ylabel = auto_row_name
+    if xtick_labels == 'auto': xtick_labels = auto_col_labels
+    if ytick_labels == 'auto': ytick_labels = auto_row_labels
+    if xlabel == 'auto': xlabel = auto_col_name
+    if ylabel == 'auto': ylabel = auto_row_name
 
     if isinstance(z, pandas.DataFrame):
         values = z.values


### PR DESCRIPTION
This idiom (formerly ok?) now causes a SyntaxWarning.

Replacing the use of `is` to compare with a constant by `==` causes the syntax warning to go away.