### PR TITLE
Fix for collections moved in python3.10

### DIFF
--- a/FlowCytometryTools/core/bases.py
+++ b/FlowCytometryTools/core/bases.py
@@ -351,6 +351,13 @@ class Measurement(BaseObject):
 Well = Measurement
 
 import collections
+try:
+    from collections import abc
+    collections.MutableMapping = abc.MutableMapping
+    collections.Iterable = abc.Iterable
+    collections.Mapping = abc.Mapping
+except:
+    pass
 
 
 class MeasurementCollection(collections.MutableMapping, BaseObject):


### PR DESCRIPTION
MutableMapping, Iterable, and Mapping were moved to collections.abc in python v3.10. This fix should work on v3.10 and earlier versions.